### PR TITLE
Improve CI checks for the stable branch

### DIFF
--- a/.github/workflows/sanitycheck-commit.yml
+++ b/.github/workflows/sanitycheck-commit.yml
@@ -1,4 +1,4 @@
-name: Sanity check
+name: Sanity check for pushes
 
 on: 
   push:

--- a/.github/workflows/sanitycheck-commit.yml
+++ b/.github/workflows/sanitycheck-commit.yml
@@ -1,13 +1,18 @@
 name: Sanity check
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - latest-stable
 
 jobs:
   sanity-check:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+
     runs-on: ${{ matrix.os }}
+
     steps:
       - uses: alire-project/setup-alire@latest-stable
       - run: alr version

--- a/.github/workflows/sanitycheck-pr.yml
+++ b/.github/workflows/sanitycheck-pr.yml
@@ -2,7 +2,7 @@
 # latest-stable-next. This way we can check the action just as GHA is going to
 # use it.
 
-name: Sanity check
+name: Sanity check for PRs
 
 on: pull-request
 

--- a/.github/workflows/sanitycheck-pr.yml
+++ b/.github/workflows/sanitycheck-pr.yml
@@ -1,0 +1,26 @@
+# Changes to the latest-stable branch must be proposed via PRs in the branch
+# latest-stable-next. This way we can check the action just as GHA is going to
+# use it.
+
+name: Sanity check
+
+on: pull-request
+
+jobs:
+  sanity-check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Check on proper branch
+        if: github.head_ref != 'latest-stable-next'
+        uses: actions/github-script@v3
+        with:
+        script: |
+          core.setFailed('PRs for latest-stable must come from latest-stable-next')
+
+      - uses: alire-project/setup-alire@latest-stable-next
+
+      - run: alr version


### PR DESCRIPTION
To ensure we properly test the action, merges to `latest-stable` must be made from `latest-stable-next`. This means only one at a time can be pending, but since we don't see much traffic here...