### PR TITLE
Self-building action variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 GitHub action to setup Alire, the Ada/SPARK package manager, from the
 development branch. This action also takes care of setting up a compiler to
-carry out the build.
+carry out the build of Alire. However, after the action completes, Alire will
+be configured to rely on the compiler configured via `alr toolchain`.
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -15,8 +15,17 @@ inputs:
 runs:
   using: 'composite'
   steps: 
-    - name: Set up GNAT
-      uses: ada-actions/toolchain@ce2020
+    - name: Set up GNAT (FSF)
+      if: runner.os == 'Linux'
+      uses: ada-actions/toolchain@ce2021
+      with:
+        distrib: fsf
+
+    - name: Set up GNAT (FSF)
+      if: runner.os != 'Linux'
+      uses: ada-actions/toolchain@ce2021
+      with:
+        distrib: community
 
     - name: Set up Alire
       uses: alire-project/setup-alire@latest-devel

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   toolchain:
     description: Arguments to pass to `alr toolchain` after setup
     required: false
-    default: 'gnat_native gprbuild<2000'
+    default: 'gnat_native gprbuild'
   toolchain_dir:
     description: Location to install the toolchain under
     required: false
@@ -21,5 +21,5 @@ runs:
     - name: Set up Alire
       uses: alire-project/setup-alire@latest-devel
       with:
-        toolchain: ${{ toolchain }}
-        toolchain_dir: ${{ toolchain_dir }}
+        toolchain: ${{ inputs.toolchain }}
+        toolchain_dir: ${{ inputs.toolchain_dir }}

--- a/action.yml
+++ b/action.yml
@@ -15,15 +15,22 @@ inputs:
 runs:
   using: 'composite'
   steps: 
-    - name: Set up GNAT (FSF)
-      if: runner.os == 'Linux'
-      uses: ada-actions/toolchain@ce2021
-      with:
-        distrib: fsf
+#    - name: Set up GNAT (FSF)
+#      if: runner.os == 'Linux'
+#      uses: ada-actions/toolchain@ce2021
+#      with:
+#        distrib: fsf
+#
+#    - name: Set up GNAT (CE)
+#      if: runner.os != 'Linux'
+#      uses: ada-actions/toolchain@ce2021
+#      with:
+#        distrib: community
 
-    - name: Set up GNAT (FSF)
-      if: runner.os != 'Linux'
-      uses: ada-actions/toolchain@ce2021
+    # Until conditionals work in composite actions, we are forced to use always
+    # the CE edition
+    - name: Set up GNAT (CE)
+      uses: ada-actions/toolchain@ce2020 # 2020 required for macOS
       with:
         distrib: community
 


### PR DESCRIPTION
This action branch sets up alire from the devel branch, installing a compiler to be able to build it. So workflows need not setup a compiler explicitly to use devel alr.