### PR TITLE
Enable caching for all setup modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ inputs:
     required: false
     default: ''
   cache:
-    description: Whether to reuse a cached previous install. Only works for stable releases.
+    description: Whether to reuse a cached previous install.
     required: false
     default: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ''
   cache:
-    description: Whether to reuse a cached previous install. Only works for stable releases with toolchain at default location.
+    description: Whether to reuse a cached previous install.
     required: false
     default: true
 
@@ -33,7 +33,18 @@ runs:
   using: "composite"
   steps:
 
-    # We don't cache branch builds for now, as this would require to check the head commit
+    - name: Identify hash from which alr was built
+      id: find-hash
+      shell: bash
+      run: |
+        if [ "${{ inputs.branch }}" != "" ]; then
+          echo "hash=(git ls-remote --heads https://github.com/alire-project/alire ${{ inputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
+        elsif [ "${{ inputs.version }}" != "nightly" ]; then
+          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire v${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+        else
+          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire ${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+        fi
+
     - name: Reuse cached installation
       if: ${{ inputs.cache == 'true' && inputs.branch == '' && inputs.version != 'nightly' && inputs.toolchain_dir == '' }}
       id: cache-alr
@@ -43,7 +54,7 @@ runs:
           ~/.cache/alire
           ~/.config/alire
           ./alire_install
-        key: alr[${{ inputs.version }}][${{ inputs.toolchain }}][${{ runner.os }}]
+        key: alr[${{ inputs.version }}][${{ inputs.toolchain }}][${{ runner.os }}][${{ steps.find-hash.outputs.hash }}]
         # .cache contains msys64 install on Windows
         # .config contains the toolchain at the default location, besides index config
         # ./alire_install contains alr itself


### PR DESCRIPTION
We rely on the commit hash to uniquely identify each cache, so it's safe to cache even nightly or built from sources.