### PR TITLE
Enable caching for all setup modes

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -42,7 +42,6 @@ jobs:
         if: matrix.target == 'source'
         with:
           distrib: community
-          cache: false
 
       - name: Setup from source
         uses: alire-project/setup-alire@v2-next

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -68,3 +68,17 @@ jobs:
               core.setFailed('FAIL: No cache hit observed')
 
       - run: alr -n version
+
+      # Verify proper builds
+
+      - run: alr -n version | grep "os:" | grep LINUX
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+
+      - run: alr -n version | grep "os:" | grep MACOS
+        if: matrix.os == 'macos-latest'
+        shell: bash
+
+      - run: alr -n version | grep "os:" | grep WINDOWS
+        if: matrix.os == 'windows-latest'
+        shell: bash

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -2,7 +2,7 @@
 # v2-next. This way we can check the action just as GHA is going to
 # use it.
 
-name: Test cache (stable)
+name: Test cache
 
 on:
   pull_request:
@@ -12,6 +12,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        version: ['1.2.2', 'nightly', 'source']
+        branch: ['', 'master']
+        exclude: # These combos are redundant
+          - version: '1.2.2'
+            branch: master
+          - version: nightly
+            branch: master
+          - version: source
+            branch: ''
 
     runs-on: ${{ matrix.os }}
 
@@ -23,11 +32,19 @@ jobs:
           script: |
             core.setFailed(`PRs for ${{github.base_ref}} must come from v2-next, but branch is ${{github.head_ref || github.ref}}`)
 
+      - uses: ada-actions/toolchain@ce2020
+        if: matrix.branch == 'master'
+        with:
+          distrib: community
+
       # This might hit cache
 
       - name: Check action itself
         id: attempt_1
         uses: alire-project/setup-alire@v2-next
+        with:
+          version: ${{matrix.version}}
+          branch: ${{matrix.branch}}
 
       # Next attemp should hit cache given the previous run
 
@@ -35,6 +52,9 @@ jobs:
         if: steps.attempt_1.outputs.cache_hit != 'true'
         id: attempt_2
         uses: alire-project/setup-alire@v2-next
+        with:
+          version: ${{matrix.version}}
+          branch: ${{matrix.branch}}
 
       - shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ inputs:
     required: false
     default: ''
   cache:
-    description: Whether to reuse a cached previous install. Only works for stable releases.
+    description: Whether to reuse a cached previous install.
     required: false
     default: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -37,12 +37,12 @@ runs:
       id: find-hash
       shell: bash
       run: |
-        if [ "${{ inputs.branch }}" != "" ]; then
-          echo "hash=(git ls-remote --heads https://github.com/alire-project/alire ${{ inputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
-        elsif [ "${{ inputs.version }}" != "nightly" ]; then
-          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire v${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+        if [[ "${{ inputs.branch }}" != "" ]]; then
+          echo "hash=$(git ls-remote --heads https://github.com/alire-project/alire ${{ inputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
+        elif [[ "${{ inputs.version }}" != "nightly" ]]; then
+          echo "hash=$(git ls-remote --tags https://github.com/alire-project/alire v${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
         else
-          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire ${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+          echo "hash=$(git ls-remote --tags https://github.com/alire-project/alire ${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
         fi
 
     - name: Reuse cached installation

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ inputs:
     description: Use this argument to install a stable or nightly release. Use a version number without v prefix, e.g., 1.0.1, 1.1.0, or 'nightly'. This argument will be ignored if a branch argument is supplied. Defaults to the latest stable release.
     required: false
     default: '1.2.2'
+    # Also to be updated in test-cache-yml
   branch:
     description: Use this argument to install a development branch (e.g., master). Using this option will require a preexisting compiler in the workflow environment.
     required: false
@@ -46,7 +47,7 @@ runs:
         fi
 
     - name: Reuse cached installation
-      if: ${{ inputs.cache == 'true' && inputs.branch == '' && inputs.version != 'nightly' && inputs.toolchain_dir == '' }}
+      if: ${{ inputs.cache == 'true' && inputs.toolchain_dir == '' }}
       id: cache-alr
       uses: actions/cache/restore@v3
       with:
@@ -62,7 +63,7 @@ runs:
     - name: Check cache output
       shell: bash
       run: |
-        echo Cache hit result: ${{ steps.cache-alr.outputs.cache-hit }}
+        echo Cache hit result: [${{ steps.cache-alr.outputs.cache-hit }}] cache-id: ${{ steps.find-hash.outputs.hash }}
 
     # To run the old setup action which is javascript
     - name: Setup Node
@@ -86,7 +87,7 @@ runs:
     # Save cache early so we can verify its proper working in a test workflow. Otherwise
     # it's not saved until workflow completion and by then it's too late.
     - name: Cache install
-      if: ${{ inputs.cache == 'true' && inputs.branch == '' && inputs.version != 'nightly' && inputs.toolchain_dir == '' }}
+      if: ${{ inputs.cache == 'true' && inputs.toolchain_dir == '' }}
       uses: actions/cache/save@v3
       with:
         path: |

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ''
   cache:
-    description: Whether to reuse a cached previous install. Only works for stable releases with toolchain at default location.
+    description: Whether to reuse a cached previous install.
     required: false
     default: true
 
@@ -33,7 +33,18 @@ runs:
   using: "composite"
   steps:
 
-    # We don't cache branch builds for now, as this would require to check the head commit
+    - name: Identify hash from which alr was built
+      id: find-hash
+      shell: bash
+      run: |
+        if [ "${{ inputs.branch }}" != "" ]; then
+          echo "hash=(git ls-remote --heads https://github.com/alire-project/alire ${{ inputs.branch }} | cut -f1)" >> $GITHUB_OUTPUT
+        elsif [ "${{ inputs.version }}" != "nightly" ]; then
+          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire v${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+        else
+          echo "hash=(git ls-remote --tags https://github.com/alire-project/alire ${{ inputs.version }} | cut -f1)" >> $GITHUB_OUTPUT
+        fi
+
     - name: Reuse cached installation
       if: ${{ inputs.cache == 'true' && inputs.branch == '' && inputs.version != 'nightly' && inputs.toolchain_dir == '' }}
       id: cache-alr
@@ -43,7 +54,7 @@ runs:
           ~/.cache/alire
           ~/.config/alire
           ./alire_install
-        key: alr[${{ inputs.version }}][${{ inputs.toolchain }}][${{ runner.os }}]
+        key: alr[${{ inputs.version }}][${{ inputs.toolchain }}][${{ runner.os }}][${{ steps.find-hash.outputs.hash }}]
         # .cache contains msys64 install on Windows
         # .config contains the toolchain at the default location, besides index config
         # ./alire_install contains alr itself

--- a/lib/main.js
+++ b/lib/main.js
@@ -41,11 +41,23 @@ const tc = __importStar(require("@actions/tool-cache"));
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const install_dir = "alire_install";
+function detect_cached() {
+    const ext = (process.platform == "win32" ? ".exe" : "");
+    if (fs_1.default.existsSync(path_1.default.join(process.cwd(), install_dir, "bin", `alr${ext}`))) {
+        console.log("CACHE HIT");
+        return true;
+    }
+    else {
+        console.log("CACHE MISS");
+        return false;
+    }
+}
 function install_branch(branch) {
     return __awaiter(this, void 0, void 0, function* () {
         const repo_url = "https://github.com/alire-project/alire.git";
         console.log(`Builing alr from branch [${branch}]`);
         yield exec.exec(`git clone -b ${branch} ${repo_url} ${install_dir}`);
+        const start_path = process.cwd();
         process.chdir(install_dir);
         yield exec.exec(`git submodule update --init --recursive`);
         switch (process.platform) {
@@ -71,7 +83,7 @@ function install_branch(branch) {
                 break;
         }
         yield exec.exec(`gprbuild -j0 -p -P alr_env.gpr -cargs -fPIC`);
-        core.addPath(path_1.default.join(process.cwd(), 'bin'));
+        process.chdir(start_path);
     });
 }
 function install_release(version) {
@@ -104,13 +116,6 @@ function install_release(version) {
         const v = (version == "nightly" ? "" : "v");
         const filename = `alr-${version}-${infix}-${platform}.zip`;
         const url = `${base_url}/${v}${version}/${filename}`;
-        //  Add to path in any case
-        core.addPath(path_1.default.join(process.cwd(), install_dir, 'bin'));
-        // Check if this install is cached
-        if (fs_1.default.existsSync(path_1.default.join(process.cwd(), install_dir, 'LICENSE.txt'))) {
-            console.log(`CACHE HIT: reusing installation of ${filename}`);
-            return true;
-        }
         console.log(`Downloading file: ${url} to ${install_dir}`);
         const dlFile = yield tc.downloadTool(url);
         yield tc.extractZip(dlFile, install_dir);
@@ -138,15 +143,18 @@ function run() {
                 tool_args = core.getInput('toolchain');
                 tool_dir = core.getInput('toolchain_dir');
             }
-            // Install the requested version/branch
-            var cached;
-            if (branch.length == 0) {
-                cached = yield install_release(version);
+            // Install the requested version/branch unless cached
+            const cached = detect_cached();
+            if (!cached) {
+                if (branch.length == 0) {
+                    yield install_release(version);
+                }
+                else {
+                    yield install_branch(branch);
+                }
             }
-            else {
-                yield install_branch(branch);
-                cached = false;
-            }
+            //  Add to path in any case
+            core.addPath(path_1.default.join(process.cwd(), install_dir, 'bin'));
             // And configure the toolchain
             if (tool_args.length > 0 && !cached) {
                 if (tool_dir.length == 0) {


### PR DESCRIPTION
We rely on the commit hash to uniquely identify each cache, so it's safe to cache even nightly or built from sources.