### PR TITLE
Install toolchain only when needed to build from sources

### DIFF
--- a/.github/workflows/selftest.yml
+++ b/.github/workflows/selftest.yml
@@ -38,11 +38,6 @@ jobs:
           version: nightly
           cache: false
 
-      - uses: ada-actions/toolchain@ce2020
-        if: matrix.target == 'source'
-        with:
-          distrib: community
-
       - name: Setup from source
         uses: alire-project/setup-alire@v2-next
         if: matrix.target == 'source'

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -32,11 +32,6 @@ jobs:
           script: |
             core.setFailed(`PRs for ${{github.base_ref}} must come from v2-next, but branch is ${{github.head_ref || github.ref}}`)
 
-      - uses: ada-actions/toolchain@ce2020
-        if: matrix.branch == 'master'
-        with:
-          distrib: community
-
       # This might hit cache
 
       - name: Check action itself

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use a precompiled nightly build of the development version, use the following
 To use a development version compiled from sources (if you known what
 you are doing), use the following:
 ```yaml
-    - uses: alire-project/setup-alire@v1
+    - uses: alire-project/setup-alire@v2
       with:
         branch: "master" # or the branch you want to use
 ```

--- a/README.md
+++ b/README.md
@@ -19,18 +19,18 @@ To use a precompiled nightly build of the development version, use the following
 ```
 
 To use a development version compiled from sources (if you known what
-you are doing), add instead these two steps to you workflow:
+you are doing), use the following:
 ```yaml
-    - uses: ada-actions/toolchain@ce2020
     - uses: alire-project/setup-alire@v1
       with:
         branch: "master" # or the branch you want to use
 ```
-The first step, in this case, is done to have a GNAT toolchain available to
-compile Alire. If you already are setting up GNAT for your needs, this step can
-be omitted.
 
-The command line tool `alr` will be available in `PATH`.
+For building from sources, the action will detect whether a GNAT is already in
+the PATH. If not, one will be installed to be able to build `alr`.
+
+The command-line tool `alr` will be available in `PATH` after the action
+completes.
 
 More generally, these options are available for the action:
 
@@ -39,7 +39,7 @@ inputs:
   version:
     description: Use this argument to install a stable release. Use a version number without v prefix, e.g., 1.0.1, 1.1.0. This argument will be ignored if a branch argument is supplied. Defaults to the latest stable release.
     required: false
-    default: '1.1.0'
+    default: '1.2.2'
   branch:
     description: Use this argument to install a development branch (e.g., master). Using this option will require a preexisting compiler in the workflow environment.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -71,9 +71,9 @@ runs:
       id: find-gnat
       run: gnat --version && echo "available=true" >> $GITHUB_OUTPUT || echo "available=false" >> $GITHUB_OUTPUT
 
-    # Setup a GNAT if necessary
+    # Setup a GNAT if necessary to build from branch
     - name: Install GNAT
-      if: steps.find-gnat.outputs.available != "true"
+      if: inputs.branch != '' && steps.find-gnat.outputs.available != 'true' && steps.cache-alr.outputs.cache-hit != 'true'
       uses: ada-actions/toolchain@ce2020
       with:
         distrib: community

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,19 @@ runs:
       run: |
         echo Cache hit result: [${{ steps.cache-alr.outputs.cache-hit }}] cache-id: ${{ steps.find-hash.outputs.hash }}
 
+    # Ascertain if we need to install a toolchain for building from sources
+    - name: Find GNAT
+      shell: bash
+      id: find-gnat
+      run: gnat --version && echo "available=true" >> $GITHUB_OUTPUT || echo "available=false" >> $GITHUB_OUTPUT
+
+    # Setup a GNAT if necessary
+    - name: Install GNAT
+      if: steps.find-gnat.outputs.available != "true"
+      uses: ada-actions/toolchain@ce2020
+      with:
+        distrib: community
+
     # To run the old setup action which is javascript
     - name: Setup Node
       uses: actions/setup-node@v3


### PR DESCRIPTION
Will reuse one in the environment, but otherwise it removes the onus from users of the action to provide it