### PR TITLE
Disable asking for permission to auto-refresh index

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,11 +159,12 @@ runs:
       run: |
         rm -rf setup_alire_prefix && echo REMOVED toolchain used to build alr
 
-    # Display result for the record
+    # Display result for the record, and do some housekeeping
     - shell: bash
       run: |
         which alr
         alr --version
+        { alr index --update-all >/dev/null && echo "Index refreshed"; } || echo "Index refresh failed"
 
     # Save cache early so we can verify its proper working in a test workflow. Otherwise
     # it's not saved until workflow completion and by then it's too late.

--- a/lib/main.js
+++ b/lib/main.js
@@ -152,6 +152,13 @@ function run() {
             }
             //  Add to path in any case
             core.addPath(path_1.default.join(process.cwd(), install_dir, 'bin'));
+            //  Disable index auto-refresh asking, that may cause trouble to users
+            //  on first run, but only if the major version is >=2, which
+            //  introduced the feature.
+            if (parseInt(version.split(".")[0], 10) >= 2) {
+                yield exec.exec(`alr -n settings --global --set index.auto_update_asked true`);
+                console.log("Enabled index auto-refresh without further asking.");
+            }
             // And configure the toolchain
             if (tool_args.length > 0 && !cached) {
                 yield exec.exec(`alr -n toolchain ${tool_args != "--disable-assistant" ? "--select " : ""} ${tool_args}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,6 +132,14 @@ async function run() {
         //  Add to path in any case
         core.addPath(path.join(process.cwd(), install_dir, 'bin'));
 
+        //  Disable index auto-refresh asking, that may cause trouble to users
+        //  on first run, but only if the major version is >=2, which
+        //  introduced the feature.
+        if (parseInt(version.split(".")[0], 10) >= 2) {
+            await exec.exec(`alr -n settings --global --set index.auto_update_asked true`);
+            console.log("Enabled index auto-refresh without further asking.");
+        }
+
         // And configure the toolchain
         if (tool_args.length > 0 && !cached) {
             await exec.exec(`alr -n toolchain ${tool_args != "--disable-assistant" ? "--select " : ""} ${tool_args}`);


### PR DESCRIPTION
Depending on when this popped-up, it could play foul with scripts using `alr`